### PR TITLE
fix typo on home page

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -27,7 +27,7 @@ The following design systems and libraries currently adhere to the specification
 
 - [GitHub's Primer Components](https://primer.style/components)
 - [Artsy's Palette](https://palette.artsy.net/)
-- [SproutSocial's Seeds](https://sproutsocial.com/seeds/)
+- [Sprout Social's Seeds](https://sproutsocial.com/seeds/)
 - [Modulz Radix](https://radix.modulz.app/docs/getting-started/)
 - [Priceline Design System](https://pricelinelabs.github.io/design-system/)
 - [Styled System](https://styled-system.com)


### PR DESCRIPTION
Tiny detail, but it's "Sprout Social", not "SproutSocial" 😊 